### PR TITLE
SFPlayerView: remove duplicate variable declaration.

### DIFF
--- a/Classes/SFPlayer.sc
+++ b/Classes/SFPlayer.sc
@@ -584,7 +584,6 @@ SFPlayerView {
 	var cueOffsetNum, cueMenu;
 	var scope;
 	var <timeString, <timeStringSm, <sfView, <cuesView, <gridView, <timeGrid, <zoomView, <zoomImage, guiRoutine, <filenameString;
-	var <skin;
 	var <zoomLo = 0, <zoomHi = 1; // for overview on top; normalized
 	var zoomHandlePx = 8;
 	// var tempBounds, tempAction;


### PR DESCRIPTION
SC 3.16 will error out on duplicate variable declarations, so this removes one in `SFPlayerView`.